### PR TITLE
feat: register/login with auth token

### DIFF
--- a/bangazon/settings.py
+++ b/bangazon/settings.py
@@ -37,19 +37,42 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
+    'rest_framework.authtoken',
     'safedelete',
+    'corsheaders',
     'bangazonAPI',
 ]
 
+# This is new
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.AllowAny',
+    ],
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 10
+}
+
+# Replace existing list
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+# This is new
+CORS_ORIGIN_WHITELIST = (
+    'http://localhost:3000',
+    'http://127.0.0.1:3000'
+)
 
 ROOT_URLCONF = 'bangazon.urls'
 

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -24,9 +24,9 @@ router = routers.DefaultRouter(trailing_slash=False)
 
 urlpatterns = [
     path('', include(router.urls)),
-    path('admin/', admin.site.urls),
-    path('register/', register_user),
-    path('login/', login_user),
-    path('api-token-auth/', obtain_auth_token),
-    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    path('admin', admin.site.urls),
+    path('register', register_user),
+    path('login', login_user),
+    path('api-token-auth', obtain_auth_token),
+    path('api-auth', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -14,8 +14,19 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
+from rest_framework import routers
+from rest_framework.authtoken.views import obtain_auth_token
+from bangazonAPI.models import *
+from bangazonAPI.views import register_user, login_user
+
+router = routers.DefaultRouter(trailing_slash=False)
 
 urlpatterns = [
+    path('', include(router.urls)),
     path('admin/', admin.site.urls),
+    path('register/', register_user),
+    path('login/', login_user),
+    path('api-token-auth/', obtain_auth_token),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]

--- a/bangazonAPI/views/__init__.py
+++ b/bangazonAPI/views/__init__.py
@@ -1,0 +1,1 @@
+from .v_register import register_user, login_user

--- a/bangazonAPI/views/v_register.py
+++ b/bangazonAPI/views/v_register.py
@@ -1,0 +1,67 @@
+import json
+from django.http import HttpResponse
+from django.contrib.auth import login, authenticate
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+from django.views.decorators.csrf import csrf_exempt
+from bangazonAPI.models import Customer
+
+@csrf_exempt
+def login_user(request):
+    ''' Handles user authentication
+
+    Method arguments:
+        request -- full HTTP request object
+    '''
+    # load JSON string of request body into a dict
+    req_body = json.loads(request.body.decode())
+
+    if request.method == 'POST':
+
+        username = req_body['username']
+        password = req_body['password']
+        authenticated_user = authenticate(username=username, password=password)
+
+        if authenticated_user is not None:
+            # authentication was successful, respond with their token
+            token = Token.objects.get(user=authenticated_user)
+            data = json.dumps({'valid': True, 'token': token.key})
+            return HttpResponse(data, content_type='application/json')
+
+        else:
+            # Invalid login details provided
+            data = json.dumps({'valid': False})
+            return HttpResponse(data, content_type='application/json')
+
+
+@csrf_exempt
+def register_user(request):
+    '''Handles creation of new user for authentication
+
+    Method arguments:
+        request -- The full HTTP request object
+    '''
+
+    # load JSON string of request body into a dict
+    req_body = json.loads(request.body.decode())
+
+    # create new user using django's `create_user` builtin method
+    new_user = User.objects.create_user(
+        username=req_body['username'],
+        email=req_body['email'],
+        password=req_body['password'],
+        first_name=req_body['first_name'],
+        last_name=req_body['last_name']
+    )
+
+    # also create a customer after the django user is created
+    customer = Customer.objects.create(
+        user=new_user
+    )
+
+    # REST framework's token generator for new user acct
+    token = Token.objects.create(user=new_user)
+
+    # return token to client
+    data = json.dumps({'token': token.key})
+    return HttpResponse(data, content_type='application/json')


### PR DESCRIPTION
# Description

Authentication setup for Register/Login API endpoints

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions

```
git fetch --all
git checkout rb-authentication
python manage.py makemigrations
python manage.py migrate
```

1. Make sure after your migrate step that you had migrations applied related to `authuser`
2. Open up your browser and go to `http://127.0.0.1:8000/` and make sure the interactive API opens
3. Open Postman and try registering Tom Hanks to the `http://127.0.0.1:8000/register/` endpoint
```
{
    "username": "thanksWilson",
    "email": "tom@hanks.com",
    "password": "p@$$word!",
    "first_name": "Tom",
    "last_name": "Hanks"
}
```
^^JSON body
Headers: `Content-type: application/json`
4. Make sure you get back a valid token. Copy this token value for the next testing step
5. Check the `http://127.0.0.1:8000/login/` endpoint to get back Tom Hanks' valid login
```
{
    "username": "thanksWilson",
    "password": "p@$$word!"
}
```
^^JSON body
Headers: `Content-type: application/json; Authorization: Token [paste token here]`
6. Check that you get a JSON-object back with a `Valid: true` key included with the token

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
