### PR TITLE
Rb safe delete

### DIFF
--- a/bangazon/settings.py
+++ b/bangazon/settings.py
@@ -71,7 +71,9 @@ MIDDLEWARE = [
 # This is new
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:8000',
-    'http://127.0.0.1:8000'
+    'http://127.0.0.1:8000',
+    'http://localhost:3000',
+    'http://127.0.0.1:3000',
 )
 
 ROOT_URLCONF = 'bangazon.urls'

--- a/bangazonAPI/models/order_product.py
+++ b/bangazonAPI/models/order_product.py
@@ -5,7 +5,7 @@ from .order import Order
 
 class OrderProduct(models.Model):
     order = models.ForeignKey(Order, on_delete=models.CASCADE)
-    product = models.ForeignKey(Product, on_delete=models.SET_NULL, null=True)
+    product = models.ForeignKey(Product, on_delete=models.CASCADE, null=True)
 
     class Meta:
         ordering = (F("order").desc(),)

--- a/bangazonAPI/models/payment_type.py
+++ b/bangazonAPI/models/payment_type.py
@@ -1,8 +1,13 @@
 from django.db import models
 from django.db.models import F
+from safedelete.models import SafeDeleteModel
+from safedelete.models import HARD_DELETE_NOCASCADE
 from .customer import Customer
 
-class PaymentType(models.Model):
+class PaymentType(SafeDeleteModel):
+    # Objects will be hard-deleted, or soft deleted if other objects would have been deleted too.
+    _safedelete_policy = HARD_DELETE_NOCASCADE
+
     merchant_name = models.CharField(max_length=25)
     acct_no = models.CharField(max_length=25)
     expiration_date = models.DateTimeField(auto_now=False, auto_now_add=False)

--- a/bangazonAPI/models/product.py
+++ b/bangazonAPI/models/product.py
@@ -9,7 +9,7 @@ from .product_type import ProductType
 class Product(SafeDeleteModel):
     # Objects will be hard-deleted, or soft deleted if other objects would have been deleted too.
     _safedelete_policy = HARD_DELETE_NOCASCADE
-    
+
     name = models.CharField(max_length=55)
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
     price = models.FloatField()
@@ -18,7 +18,7 @@ class Product(SafeDeleteModel):
     location = models.CharField(max_length=75, null=True)
     image_path = models.CharField(max_length=255)
     created_at = models.DateTimeField(auto_now=False, auto_now_add=True)
-    product_type = models.ForeignKey(ProductType, on_delete=models.SET_NULL, null=True)
+    product_type = models.ForeignKey(ProductType, on_delete=models.CASCADE, null=True)
 
     class Meta:
         ordering = (F("created_at").desc(), )

--- a/bangazonAPI/models/product.py
+++ b/bangazonAPI/models/product.py
@@ -1,10 +1,15 @@
 from django.db import models
 from django.db.models import F
+from safedelete.models import SafeDeleteModel
+from safedelete.models import HARD_DELETE_NOCASCADE
 from .customer import Customer
 from .product_type import ProductType
 
 
-class Product(models.Model):
+class Product(SafeDeleteModel):
+    # Objects will be hard-deleted, or soft deleted if other objects would have been deleted too.
+    _safedelete_policy = HARD_DELETE_NOCASCADE
+    
     name = models.CharField(max_length=55)
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
     price = models.FloatField()


### PR DESCRIPTION
# Description

FEATURE: `django-safe-delete` implemented for deleting `Products` and `Payment Types`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
```shell
git fetch --all
git checkout rb-safe-delete
```
1. `python manage.py makemigrations`
1. `python manage.py migrate`
1. You should see that the `deleted` field is added to both the `products` and `paymenttypes` models
1. `python manage.py runserver`

**DELETE PAYMENT TYPE**
1. Open Postman and check that you have an active `order` with payment type attached
1. **DELETE** the payment type attached to that order at the `paymenttypes/<int>` endpoint
1. Do a **GET** for the `orders` endpoint and see that the order still exists

**DELETE PRODUCT**
1. Open Postman and check that you have item(s) in the `orderproducts` endpoint (**GET**)
1. On the `products/<id>` endpoint, **DELETE** a product attached to the previous `orderproducts` item
1. Do a second **GET** for the `orderproducts` endpoint and see that the orderproduct still exists and that the product_id is still there

**(OPTIONAL)**
1. Check all these things in DBeaver or Tableplus and see how the `deleted` column is added to the `products` and `paymenttypes` tables and is filled in with DATETIME value if you have soft-deleted that item

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
